### PR TITLE
Fix edited reward recipes failing to retrain

### DIFF
--- a/duck-viewer/components/TeachPanel.tsx
+++ b/duck-viewer/components/TeachPanel.tsx
@@ -557,7 +557,10 @@ function RecipeEditor({
                 byPolarity(pickable).map((a) => (
                   <button
                     key={a.key}
-                    onClick={() => setAdded((w) => ({ ...w, [a.key]: a.weight }))}
+                    onClick={() => {
+                      setAdded((w) => ({ ...w, [a.key]: a.weight }));
+                      setPickerOpen(false);
+                    }}
                     style={{
                       display: "flex",
                       alignItems: "center",
@@ -1219,6 +1222,7 @@ export function TeachPanel({
    *  the server's per-behavior memory the fallback. */
   async function postTeach(body: {
     text: string;
+    clip?: string;
     weights?: Record<string, number>;
     stageWeights?: Record<string, Record<string, number>>;
     stageSteps?: Record<string, number>;
@@ -1288,6 +1292,7 @@ export function TeachPanel({
     stageWeights: Record<string, Record<string, number>> | null
   ) {
     if (!training) return;
+    const clip = training.behavior.clip;
     const n = Object.keys(weights).length;
     const tweak = n ? ` with ${n} adjusted weight${n > 1 ? "s" : ""}` : "";
     setMsgs((m) => [
@@ -1300,7 +1305,12 @@ export function TeachPanel({
       },
     ]);
     await postTeach({
-      text: training.behavior.title,
+      // Imitation cards replace the matchable title "Copy the animation"
+      // with a clip-specific display title such as `Perform “…”`.
+      // Keep matching on the behavior id and carry the clip explicitly so a
+      // retrain/fine-tune cannot fail matching or silently use another clip.
+      text: training.behavior.id === "imitate" ? "imitate" : training.behavior.title,
+      ...(clip ? { clip } : {}),
       ...(n ? { weights } : {}),
       ...(fineTune ? { initFrom: training.runName } : {}),
       ...(!fineTune && stageWeights ? { stageWeights } : {}),

--- a/duck-viewer/components/TeachPanel.tsx
+++ b/duck-viewer/components/TeachPanel.tsx
@@ -1305,11 +1305,12 @@ export function TeachPanel({
       },
     ]);
     await postTeach({
-      // Imitation cards replace the matchable title "Copy the animation"
-      // with a clip-specific display title such as `Perform “…”`.
-      // Keep matching on the behavior id and carry the clip explicitly so a
-      // retrain/fine-tune cannot fail matching or silently use another clip.
-      text: training.behavior.id === "imitate" ? "imitate" : training.behavior.title,
+      // The stable id, never the card's title: the server matches an id
+      // exactly, while a title is display text — an imitation card is
+      // titled `Perform “<clip>”`, and scored as prose that reached
+      // whichever recipe owned a keyword inside the clip's name. The clip
+      // rides along explicitly so a retrain/fine-tune trains the same motion.
+      text: training.behavior.id,
       ...(clip ? { clip } : {}),
       ...(n ? { weights } : {}),
       ...(fineTune ? { initFrom: training.runName } : {}),

--- a/duck-viewer/lib/lab.ts
+++ b/duck-viewer/lib/lab.ts
@@ -94,6 +94,9 @@ export interface BehaviorCard {
   id: string;
   emoji: string;
   title: string;
+  /** Authored motion clip used by imitation runs. The server includes this
+   *  when the display title is specialized to `Perform “…”`. */
+  clip?: string;
   description: string;
   howItLearns: string;
   successMetric: string;

--- a/microduck_local/src/microduck_local/behaviors/core.py
+++ b/microduck_local/src/microduck_local/behaviors/core.py
@@ -598,7 +598,16 @@ def _register(b: Behavior) -> None:
 
 
 def match_behavior(text: str) -> Behavior | None:
-    """Cheap keyword matcher from a chat message to a behavior."""
+    """Cheap keyword matcher from a chat message to a behavior.
+
+    A bare behavior id ("imitate", "one_leg") matches exactly, before any
+    keyword scoring: that is how the teach panel resubmits a run's recipe.
+    Its cards may carry a DISPLAY title the keywords never see — an
+    imitation run is titled after its clip, `Perform “backflip”`, and
+    scored as prose that text reaches the floor-roll recipe instead."""
+    key = text.strip().lower()
+    if key in BEHAVIORS:
+        return BEHAVIORS[key]
     t = " " + text.lower().replace("1", "one").strip() + " "
     best, best_score = None, 0.0
     for b in BEHAVIORS.values():

--- a/microduck_local/src/microduck_local/train_behavior.py
+++ b/microduck_local/src/microduck_local/train_behavior.py
@@ -43,7 +43,8 @@ from pathlib import Path
 
 import numpy as np
 
-from .behaviors import BEHAVIORS, Behavior, BehaviorEnv, is_symmetric
+from .behaviors import (BEHAVIORS, Behavior, BehaviorEnv, is_symmetric,
+                        resolve_clip_name)
 from .ppo_hparams import (
     DEFAULT_DESIRED_KL,
     DEFAULT_SYMMETRY_COEF,
@@ -344,9 +345,13 @@ def main() -> None:
     out.mkdir(parents=True, exist_ok=True)
     # Weights go in behavior.json so a restarted/inspected run can't silently
     # train under a different scorecard than the one on record.
+    # The clip too: an imitation run is about ONE authored motion, and the
+    # lab re-seats finished runs from this file (TrainingJob.adopt) — without
+    # it a ✨ fine-tune silently practiced the recipe's default clip.
     (out / "behavior.json").write_text(json.dumps(
         {"behavior": b.id, "steps": steps, "weights": weights,
-         "symmetry_coef": symmetry_coef, "desired_kl": args.desired_kl}))
+         "symmetry_coef": symmetry_coef, "desired_kl": args.desired_kl,
+         "clip": resolve_clip_name(b)}))
 
     # Fork workers BEFORE importing torch. A torch-initialized parent has
     # OpenMP/Accelerate thread pools; forking them deadlocks on macOS.

--- a/microduck_local/src/microduck_local/viz_server.py
+++ b/microduck_local/src/microduck_local/viz_server.py
@@ -1058,7 +1058,11 @@ class TrainingJob:
         # Seated, not launched: created no preview ducks (redundant with the
         # class default, stated here so the contract is visible at the site).
         self.owns_preview_ducks = False
-        self.extra_env = {}
+        # The run's clip comes back with it (train_behavior records it), so
+        # the card says `Perform “<clip>”` and a fine-tune trains the SAME
+        # motion. Older runs predate the record: they seat clip-less.
+        clip = meta.get("clip")
+        self.extra_env = {"MICRODUCK_CLIP": clip} if clip else {}
         self.stages = ()
         self._start_idx = 0
         self.stage_idx = 0
@@ -1821,6 +1825,31 @@ def resolve_init_from(name: str) -> Path:
         raise ValueError(f"initFrom run {name!r} has no {' / '.join(missing)} "
                          "yet — it can't be warm-started")
     return run
+
+
+def run_clip(run: Path) -> str | None:
+    """The clip a run trained against, from its behavior.json — None for
+    runs without one (non-imitation recipes, or records that predate it)."""
+    try:
+        clip = json.loads((run / "behavior.json").read_text()).get("clip")
+    except (OSError, ValueError):
+        return None
+    return clip if isinstance(clip, str) and clip else None
+
+
+# The lab's OWN display title for an imitation job (TrainingJob.display_title).
+# A client that echoes it back as the /teach text — the panel did, before it
+# learned to send the behavior id — must reach the imitation recipe with that
+# clip, never a recipe that happens to own a keyword inside the clip's name.
+_DISPLAY_TITLE_RE = re.compile(r"\s*perform\s+[“\"](.+?)[”\"]\s*$", re.IGNORECASE)
+
+
+def match_teach_text(text: str) -> tuple["behaviors_mod.Behavior | None", str | None]:
+    """(behavior, clip-implied-by-the-text) for a /teach message."""
+    m = _DISPLAY_TITLE_RE.match(text)
+    if m and "imitate" in behaviors_mod.BEHAVIORS:
+        return behaviors_mod.BEHAVIORS["imitate"], m.group(1)
+    return behaviors_mod.match_behavior(text), None
 
 
 class LabState:
@@ -2930,7 +2959,7 @@ def make_app(ducks: list[Duck]):
             return {"matched": False,
                     "message": f"behaviors.py didn't load: {e}"}
         _TRICK_DUCK_CACHE.clear()   # verdicts derive from the reloaded recipes
-        b = behaviors_mod.match_behavior(req.text)
+        b, title_clip = match_teach_text(req.text)
         if b is None:
             return {"matched": False,
                     "message": "I don't know that trick yet. I can teach these — "
@@ -2944,18 +2973,23 @@ def make_app(ducks: list[Duck]):
         # endpoint uses, and must actually exist. Unchecked, "../x" read JSON
         # outside clips/, and a typo'd name reported a healthy job whose
         # workers all died at env construction with FileNotFoundError.
-        if req.clip:
-            try:
-                if not clip_path(req.clip).exists():
-                    return {"matched": False,
-                            "message": f"I don't have a clip named “{req.clip}” — "
-                                       "save it in the 🎬 animate panel first."}
-            except ValueError as e:
-                return {"matched": False, "message": str(e)}
         init_from = None
         if req.initFrom:
             try:
                 init_from = resolve_init_from(req.initFrom)
+            except ValueError as e:
+                return {"matched": False, "message": str(e)}
+        # Which clip: the request's, else the one its title names, else — for
+        # a fine-tune — the one the run being refined actually trained on.
+        # The recipe's default clip is the last resort, never a silent swap
+        # away from the motion a finished run was built around.
+        clip = req.clip or title_clip or (run_clip(init_from) if init_from else None)
+        if clip:
+            try:
+                if not clip_path(clip).exists():
+                    return {"matched": False,
+                            "message": f"I don't have a clip named “{clip}” — "
+                                       "save it in the 🎬 animate panel first."}
             except ValueError as e:
                 return {"matched": False, "message": str(e)}
         # startStage: begin the chain partway, warm-started from the newest
@@ -3019,7 +3053,7 @@ def make_app(ducks: list[Duck]):
             stage_weights=stage_weights,
             start_stage=start_stage,
             stage_init_from=stage_init,
-            extra_env=({"MICRODUCK_CLIP": req.clip} if req.clip else None),
+            extra_env=({"MICRODUCK_CLIP": clip} if clip else None),
             budget=budget,
             stage_budgets=stage_budgets,
         )

--- a/microduck_local/tests/test_behaviors.py
+++ b/microduck_local/tests/test_behaviors.py
@@ -96,6 +96,19 @@ def test_matcher():
     assert match_behavior("wave hello") is None
 
 
+def test_matcher_takes_a_bare_behavior_id():
+    """The teach panel resubmits a run's recipe by id. Ids are stable; card
+    titles are display text, and an imitation card's title is the clip's
+    name dressed up (`Perform “backflip”`) — scored as prose, that used to
+    land on the floor-roll recipe, so a retrain trained the wrong trick."""
+    for b in BEHAVIORS.values():
+        assert match_behavior(b.id) is b
+        assert match_behavior(f"  {b.id.upper()} ") is b
+    assert match_behavior("imitate").id == "imitate"
+    # Only the exact id short-circuits; prose still scores as prose.
+    assert match_behavior("spin please").id == "spin"
+
+
 def test_cards_are_json_friendly():
     import json
     for b in BEHAVIORS.values():

--- a/microduck_local/tests/test_lab.py
+++ b/microduck_local/tests/test_lab.py
@@ -1358,6 +1358,111 @@ def test_teach_endpoint_makes_the_budget_sticky(fake_popen, monkeypatch):
     assert V.load_teach_weights()["backflip"]["stageSteps"] == {"1": 400_000}
 
 
+# ------------------------------------------------- imitation runs keep their clip
+
+
+def _seed_clip(monkeypatch, tmp_path, name):
+    clips = tmp_path / "clips"
+    clips.mkdir(exist_ok=True)
+    monkeypatch.setenv("MICRODUCK_CLIPS_DIR", str(clips))
+    (clips / f"{name}.json").write_text(json.dumps(
+        {"version": 1, "name": name, "duration": 1.0, "loop": False,
+         "keys": [{"t": 0.0, "joints": [float(j) for j in C.DEFAULT_POSE], "rootPitch": 0.0}]}))
+
+
+def _launch_env(proc):
+    return proc.kwargs.get("env") or {}
+
+
+def test_teach_text_is_the_behavior_id(fake_popen, monkeypatch, tmp_path):
+    """The panel's retrain/fine-tune buttons send the card's id. Before, they
+    echoed its TITLE — and an imitation card is titled after its clip, so
+    `Perform “backflip”` retrained the floor-roll recipe, `Perform
+    “sprint-cycle”` the runner, and a clip named after nothing matched
+    nothing at all."""
+    import importlib
+    monkeypatch.setattr(importlib, "reload", lambda m: m)
+    _seed_clip(monkeypatch, tmp_path, "backflip")
+    app = V.make_app([])
+    teach = _endpoint(app, "/teach", "POST")
+    stop = _endpoint(app, "/teach/stop", "POST")
+
+    out = asyncio.run(teach(V.TeachReq(text="imitate", clip="backflip")))
+    assert out["matched"]
+    assert out["job"]["behavior"]["id"] == "imitate"
+    assert out["job"]["behavior"]["clip"] == "backflip"
+    assert out["job"]["behavior"]["title"] == "Perform “backflip”"
+    assert _launch_env(fake_popen[-1])["MICRODUCK_CLIP"] == "backflip"
+    asyncio.run(stop())
+
+    # The lab's own display title still reaches the imitation recipe with
+    # that clip (an older panel echoes it back verbatim) — it must never
+    # pick the recipe that owns a keyword inside the clip's name.
+    out = asyncio.run(teach(V.TeachReq(text="Perform “backflip”")))
+    assert out["matched"], out
+    assert out["job"]["behavior"]["id"] == "imitate"
+    assert _launch_env(fake_popen[-1])["MICRODUCK_CLIP"] == "backflip"
+    asyncio.run(stop())
+
+    # ...and a title naming a clip that was never saved is refused, not
+    # silently trained against the recipe's default clip.
+    out = asyncio.run(teach(V.TeachReq(text="Perform “nope”")))
+    assert not out["matched"] and "nope" in out["message"]
+
+    # Every other card id round-trips too — the panel special-cases nothing.
+    for b in B.BEHAVIORS.values():
+        out = asyncio.run(teach(V.TeachReq(text=b.id)))
+        assert out["matched"] and out["job"]["behavior"]["id"] == b.id, b.id
+        asyncio.run(stop())
+
+
+def test_adopted_imitation_run_keeps_its_clip(fake_popen, monkeypatch, tmp_path):
+    """Seating a finished imitation run (POST /teach/load — what clicking its
+    duck does) must bring its clip back: the card is titled after it, and a
+    ✨ fine-tune practices the SAME motion. train_behavior records the clip in
+    behavior.json for exactly this; a fine-tune request that omits the clip
+    inherits the run's, rather than the recipe's default."""
+    import importlib
+    monkeypatch.setattr(importlib, "reload", lambda m: m)
+    _seed_clip(monkeypatch, tmp_path, "hop")
+    _seed_clip(monkeypatch, tmp_path, "backflip")
+    run = _seed_finished_run("teach-imitate-hop-abc123", behavior="imitate")
+    json_meta = json.loads((run / "behavior.json").read_text())
+    (run / "behavior.json").write_text(json.dumps({**json_meta, "clip": "hop"}))
+    for f in ("model.zip", "vecnormalize.pkl"):
+        (run / f).write_bytes(b"x")
+    app = V.make_app([])
+    load = _endpoint(app, "/teach/load", "POST")
+    teach = _endpoint(app, "/teach", "POST")
+
+    seated = asyncio.run(load(V.LoadRunReq(policy="run:teach-imitate-hop-abc123")))
+    assert seated["ok"], seated
+    assert seated["job"]["behavior"]["clip"] == "hop"
+    assert seated["job"]["behavior"]["title"] == "Perform “hop”"
+
+    # Fine-tune the way the panel does now: id + the card's clip.
+    out = asyncio.run(teach(V.TeachReq(text="imitate", clip="hop",
+                                       initFrom="teach-imitate-hop-abc123")))
+    assert out["matched"], out
+    assert _launch_env(fake_popen[-1])["MICRODUCK_CLIP"] == "hop"
+    assert _flag(fake_popen[-1].cmd, "--init-from") == str(run)
+    asyncio.run(_endpoint(app, "/teach/stop", "POST")())
+
+    # An older panel sends no clip at all: the run's own clip still wins over
+    # the recipe default ("backflip").
+    out = asyncio.run(teach(V.TeachReq(text="imitate",
+                                       initFrom="teach-imitate-hop-abc123")))
+    assert out["matched"], out
+    assert _launch_env(fake_popen[-1])["MICRODUCK_CLIP"] == "hop"
+    asyncio.run(_endpoint(app, "/teach/stop", "POST")())
+
+    # A run that predates the record seats clip-less, like before.
+    old = _seed_finished_run("teach-imitate-old111", behavior="imitate")
+    seated = asyncio.run(load(V.LoadRunReq(policy="run:teach-imitate-old111")))
+    assert seated["ok"] and "clip" not in seated["job"]["behavior"]
+    assert V.run_clip(old) is None
+
+
 def test_teach_steps_override_does_not_poison_the_sticky_budget(fake_popen,
                                                                 monkeypatch):
     import importlib

--- a/microduck_local/tests/test_train_resume.py
+++ b/microduck_local/tests/test_train_resume.py
@@ -78,6 +78,29 @@ def test_init_from_continues_step_count(tmp_path):
     assert last.get("done") is True and last["total"] == 40000
 
 
+def test_behavior_json_records_the_clip(tmp_path, monkeypatch):
+    """An imitation run writes the clip it trained against into behavior.json
+    (the lab re-seats finished runs from that file, and a fine-tune must
+    practice the same motion); recipes without a clip record none."""
+    clips = tmp_path / "clips"
+    clips.mkdir()
+    (clips / "hop.json").write_text(json.dumps(
+        {"version": 1, "name": "hop", "duration": 0.5, "loop": False,
+         "keys": [{"t": 0.0, "joints": [0.0] * 14, "rootPitch": 0.0},
+                  {"t": 0.4, "joints": [0.0] * 14, "rootPitch": -0.3}]}))
+    monkeypatch.setenv("MICRODUCK_CLIPS_DIR", str(clips))
+    monkeypatch.setenv("MICRODUCK_CLIP", "hop")
+    _run(["imitate", "--envs", "2", "--steps", "2000", "--run-name", "cliprec",
+          "--snap-steps", "1000"], tmp_path)
+    meta = json.loads((tmp_path / "cliprec" / "behavior.json").read_text())
+    assert meta["behavior"] == "imitate" and meta["clip"] == "hop"
+
+    monkeypatch.delenv("MICRODUCK_CLIP")
+    _run(["stand", "--envs", "2", "--steps", "2000", "--run-name", "noclip",
+          "--snap-steps", "1000"], tmp_path)
+    assert json.loads((tmp_path / "noclip" / "behavior.json").read_text())["clip"] is None
+
+
 def test_export_ships_the_final_policy(tmp_path):
     """A run deploys its FINAL policy.
 


### PR DESCRIPTION
## Summary

Fix retraining and fine-tuning after editing a reward recipe in the Teach panel.

## Problem

After adding a reward term and selecting “retrain with edited recipe,” the
frontend could submit a display-only behavior title that the backend did not
recognize. As a result, the edited recipe was shown in the interface, but a new
training run did not begin.

For animation-based behaviors, the request also omitted the selected motion
clip, so the retraining request did not fully preserve the behavior being
edited.

The expanded term picker could additionally push the retrain controls outside
the visible portion of the panel, making the button appear to be missing.

## Root cause

Animation behavior cards use a clip-specific display title. The recipe editor
sent that title back through the backend’s plain-text behavior matcher, which
only recognizes the behavior’s registered title and keywords.

The editor also did not include the behavior card’s clip field in retrain or
fine-tune requests.

## Changes

- Use the stable `imitate` behavior keyword when resubmitting animation
  recipes.
- Include the selected motion clip in retrain and fine-tune requests.
- Add the optional clip field to the viewer’s `BehaviorCard` interface.
- Collapse the term picker after a term is selected so the retrain controls
  remain accessible.

## Verification

- Confirmed the previous display-title request does not match a behavior.
- Confirmed the corrected request matches the imitation behavior.
- Confirmed an edited recipe creates a new training run with its edited
  weights and begins progressing.
- `npm run lint`
- `npm run build`