### PR TITLE
Teach: retrain/fine-tune carry the seated run's full effective weights

### DIFF
--- a/duck-viewer/components/TeachPanel.tsx
+++ b/duck-viewer/components/TeachPanel.tsx
@@ -287,7 +287,12 @@ function MStepsInput({
 // --- the "edit the recipe" section -----------------------------------------
 // While training runs the sliders are the read-only truth of the live
 // scorecard; once the run ends they unlock, and the two buttons resubmit the
-// behavior with only the weights the user actually moved.
+// behavior with the run's FULL effective recipe — every term at the weight
+// the run actually trained under, the moved sliders and added terms folded
+// in. The server treats an explicit weights dict as the complete override
+// set, so sending only the touched keys silently reset every other term to
+// its recipe default (a seated imitate run's rotation_match 6.05 fell back to
+// 4.00 the moment one catalog term was added).
 
 function RecipeEditor({
   t,
@@ -296,7 +301,10 @@ function RecipeEditor({
 }: {
   t: TrainingPayload;
   wide: boolean;
-  onSubmit: (weights: Record<string, number>, fineTune: boolean) => void;
+  /** `weights` is the full effective set to train under; `changed` counts
+   *  the edits the user actually made — moved sliders plus added terms —
+   *  for the chat note. */
+  onSubmit: (weights: Record<string, number>, fineTune: boolean, changed: number) => void;
 }) {
   // Only touched sliders live here; everything else displays the effective
   // weight straight from the stream. Keyed by run so a new run resets dirt.
@@ -328,13 +336,18 @@ function RecipeEditor({
 
   const live = t.status === "training";
   const effective = (key: string, fallback: number) => t.weights[key] ?? fallback;
-  const moved: Record<string, number> = {};
+  // What the next run trains under: every recipe term at its effective
+  // weight (the stream's t.weights is what the seated run actually used),
+  // with touched sliders laid over. `movedN` is the count of real moves.
+  const submitted: Record<string, number> = {};
+  let movedN = 0;
   for (const term of t.behavior.terms) {
+    const base = effective(term.key, term.weight);
     const v = edited[term.key];
-    if (v != null && Math.abs(v - effective(term.key, term.weight)) > 1e-9)
-      moved[term.key] = v;
+    const moved = v != null && Math.abs(v - base) > 1e-9;
+    if (moved) movedN += 1;
+    submitted[term.key] = moved ? v : base;
   }
-  const movedN = Object.keys(moved).length;
 
   // Catalog terms: already-pulled ones render as regular slider rows and fold
   // into the submitted weights (adding at the default weight is itself the
@@ -345,7 +358,7 @@ function RecipeEditor({
   const addedTerms = catalog.filter((a) => !inRecipe.has(a.key) && added[a.key] != null);
   const pickable = catalog.filter((a) => !inRecipe.has(a.key) && added[a.key] == null);
   const addedN = addedTerms.length;
-  for (const a of addedTerms) moved[a.key] = added[a.key];
+  for (const a of addedTerms) submitted[a.key] = added[a.key];
 
   const btn: React.CSSProperties = {
     background: "#1c2230",
@@ -595,12 +608,12 @@ function RecipeEditor({
       {!live && (
         <div style={{ marginTop: 6 }}>
           <div style={{ display: "flex", gap: 6, flexWrap: "wrap" }}>
-            <button style={btn} onClick={() => onSubmit(moved, false)}>
+            <button style={btn} onClick={() => onSubmit(submitted, false, movedN + addedN)}>
               ↻ retrain with edited recipe
             </button>
             <button
               style={{ ...btn, color: "#d8c97d", borderColor: "#5a5233" }}
-              onClick={() => onSubmit(moved, true)}
+              onClick={() => onSubmit(submitted, true, movedN + addedN)}
             >
               ✨ fine-tune the result
             </button>
@@ -649,7 +662,8 @@ function LiveTraining({
   onRecipeSubmit: (
     weights: Record<string, number>,
     fineTune: boolean,
-    stageWeights: StageWeightsMap | null
+    stageWeights: StageWeightsMap | null,
+    changed: number
   ) => void;
   onStageWeights: (stageWeights: StageWeightsMap) => void;
   onStartStage: (idx: number, stageWeights: StageWeightsMap | null) => void;
@@ -1082,7 +1096,7 @@ function LiveTraining({
         wide={wide}
         // Pending stage edits ride the retrain (the fine-tune path is a
         // single run — the server drops them there).
-        onSubmit={(w, ft) => onRecipeSubmit(w, ft, stageWeightsOrNull())}
+        onSubmit={(w, ft, changed) => onRecipeSubmit(w, ft, stageWeightsOrNull(), changed)}
       />
     </div>
   );
@@ -1278,18 +1292,21 @@ export function TeachPanel({
     await postTeach({ text: trimmed });
   }
 
-  /** Recipe buttons: resubmit the current behavior with the moved sliders,
-   *  fresh (retrain) or warm-started from the finished run (fine-tune).
-   *  Pending per-stage edits ride the retrain path (fine-tunes are single
-   *  runs — the server ignores stage weights there, so don't send them). */
+  /** Recipe buttons: resubmit the current behavior under its full effective
+   *  recipe (the run's own weights with the moved sliders and added terms
+   *  folded in — see RecipeEditor), fresh (retrain) or warm-started from the
+   *  finished run (fine-tune). Pending per-stage edits ride the retrain path
+   *  (fine-tunes are single runs — the server ignores stage weights there,
+   *  so don't send them). `changed` is how many sliders actually moved. */
   async function submitRecipe(
     weights: Record<string, number>,
     fineTune: boolean,
-    stageWeights: Record<string, Record<string, number>> | null
+    stageWeights: Record<string, Record<string, number>> | null,
+    changed: number
   ) {
     if (!training) return;
     const n = Object.keys(weights).length;
-    const tweak = n ? ` with ${n} adjusted weight${n > 1 ? "s" : ""}` : "";
+    const tweak = changed ? ` with ${changed} adjusted weight${changed > 1 ? "s" : ""}` : "";
     setMsgs((m) => [
       ...m,
       {

--- a/microduck_local/src/microduck_local/viz_server.py
+++ b/microduck_local/src/microduck_local/viz_server.py
@@ -33,7 +33,9 @@ HTTP (default 127.0.0.1:8788):
                     none exists), "initFrom": "<run name>" to fine-tune an
                     existing run's policy under the (possibly edited) recipe
                     — that stays a SINGLE run, using the final stage's env
-                    knobs, "steps": N the TOTAL practice budget for the whole
+                    knobs, and its weights MERGE over what that run trained
+                    under (its behavior.json), so a one-slider edit can't
+                    silently reset the rest of the recipe, "steps": N the TOTAL practice budget for the whole
                     job (the panel's "how long should it practice?" control) —
                     a staged chain splits it across its stages in PROPORTION
                     to their declared steps (split_step_budget), so the
@@ -1800,6 +1802,20 @@ def resolve_stage_init(behavior_id: str, start_stage: int) -> Path:
     return max(candidates, key=lambda d: (d / "model.zip").stat().st_mtime)
 
 
+def run_trained_weights(run: Path) -> dict[str, float]:
+    """The reward weights a finished run ACTUALLY trained under — its
+    behavior.json (written by train_behavior before the first step, and the
+    same record TrainingJob.adopt seats in the panel). {} for a run that
+    predates the file or whose record is unreadable: a fine-tune of such a
+    run falls back to the recipe defaults, which is all anyone knows."""
+    try:
+        meta = json.loads((run / "behavior.json").read_text())
+    except (OSError, ValueError):
+        return {}
+    weights = meta.get("weights") if isinstance(meta, dict) else None
+    return dict(weights) if isinstance(weights, dict) else {}
+
+
 def resolve_init_from(name: str) -> Path:
     """Validate a /teach initFrom run name into a warm-startable run dir.
     Raises ValueError with a client-facing message."""
@@ -2992,12 +3008,23 @@ def make_app(ducks: list[Duck]):
         # Sticky sliders: no weights in the request means "same as I had it",
         # not "back to defaults" — inherit this behavior's last-used settings
         # (both layers: behavior-level and per-stage). Explicit values
-        # (retrain/fine-tune, or a scripted call) win and become the new
-        # sticky set.
+        # (retrain, or a scripted call) win and become the new sticky set —
+        # except for a fine-tune, whose base is the run it continues.
         sticky = load_teach_weights()
         prev_sticky = sticky.get(b.id, empty_sticky())
-        weights = (req.weights if req.weights is not None
-                   else prev_sticky["weights"] or None)
+        if init_from is not None:
+            # A fine-tune continues THAT run's brain, so its recipe is the
+            # base and the request's weights layer over it (per key) — not
+            # the sticky set, and not a replacement. Before this the panel's
+            # "touched sliders only" dict replaced everything: a run seated
+            # from /teach/load with rotation_match at 6.05 was fine-tuned
+            # after adding one catalog term, and rotation_match silently
+            # dropped back to the recipe's 4.00 with no message.
+            weights = {**run_trained_weights(init_from),
+                       **(req.weights or {})} or None
+        else:
+            weights = (req.weights if req.weights is not None
+                       else prev_sticky["weights"] or None)
         stage_weights = (req.stageWeights if req.stageWeights is not None
                          else prev_sticky["stageWeights"] or None)
         # Same "same as I had it" rule for the practice budget.

--- a/microduck_local/tests/test_lab.py
+++ b/microduck_local/tests/test_lab.py
@@ -1419,6 +1419,76 @@ def test_teach_load_seats_finished_run(fake_popen, monkeypatch):
     asyncio.run(stop())
 
 
+def test_fine_tune_merges_over_the_seated_runs_weights(fake_popen, monkeypatch):
+    """Retrain/fine-tune of a seated run must carry the weights that run
+    ACTUALLY trained under. Observed 2026-09-04: an imitate run seated via
+    /teach/load with rotation_match at 6.05 was fine-tuned after adding one
+    catalog term; the panel sent only the touched keys, the server took that
+    dict as the complete override set, and rotation_match fell back to the
+    recipe's 4.00 with no message. With initFrom the server now layers the
+    request over the run's behavior.json — a delta can't reset the rest."""
+    import importlib
+    monkeypatch.setattr(importlib, "reload", lambda m: m)
+    run = _seed_finished_run("teach-spin-seat7", weights={"spin_fast": 6.05})
+    (run / "model.zip").touch()
+    (run / "vecnormalize.pkl").touch()
+    # A stale sticky crank must NOT be the fine-tune's base either — the
+    # brain being continued is the base.
+    V.save_teach_weights({"spin": {**V.empty_sticky(),
+                                   "weights": {"spin_fast": 9.0}}})
+    app = V.make_app([])
+    load = _endpoint(app, "/teach/load", "POST")
+    teach = _endpoint(app, "/teach", "POST")
+    stop = _endpoint(app, "/teach/stop", "POST")
+
+    seated = asyncio.run(load(V.LoadRunReq(policy="run:teach-spin-seat7")))
+    assert seated["ok"] and seated["job"]["weights"]["spin_fast"] == 6.05
+
+    # The panel's old shape: only the added catalog term in `weights`.
+    out = asyncio.run(teach(V.TeachReq(text="spin in place",
+                                       initFrom="teach-spin-seat7",
+                                       weights={"head_up": 1.0})))
+    assert out["matched"]
+    argv = fake_popen[0].cmd
+    assert _flag(argv, "--init-from") == str(run)
+    assert json.loads(_flag(argv, "--weights-json")) == {"spin_fast": 6.05,
+                                                         "head_up": 1.0}
+    assert out["job"]["weights"]["spin_fast"] == 6.05
+    assert out["job"]["weights"]["head_up"] == 1.0
+    # …and the merged set is what sticks for this behavior.
+    assert V.load_teach_weights()["spin"]["weights"] == {"spin_fast": 6.05,
+                                                         "head_up": 1.0}
+    asyncio.run(stop())
+
+    # An explicit value for a key the run trained under still wins (that is
+    # the user dragging the slider), and no weights at all means "exactly
+    # what the run had", not the sticky set or the recipe defaults.
+    out = asyncio.run(teach(V.TeachReq(text="spin in place",
+                                       initFrom="teach-spin-seat7",
+                                       weights={"spin_fast": 3.0})))
+    assert json.loads(_flag(fake_popen[1].cmd, "--weights-json")) == {
+        "spin_fast": 3.0}
+    asyncio.run(stop())
+    out = asyncio.run(teach(V.TeachReq(text="spin in place",
+                                       initFrom="teach-spin-seat7")))
+    assert json.loads(_flag(fake_popen[2].cmd, "--weights-json")) == {
+        "spin_fast": 6.05}
+    asyncio.run(stop())
+
+    # A run predating behavior.json fine-tunes under the request alone.
+    bare = V.RUNS_DIR / "teach-spin-bare7"
+    bare.mkdir(parents=True)
+    (bare / "model.zip").touch()
+    (bare / "vecnormalize.pkl").touch()
+    out = asyncio.run(teach(V.TeachReq(text="spin in place",
+                                       initFrom="teach-spin-bare7",
+                                       weights={"head_up": 1.0})))
+    assert out["matched"]
+    assert json.loads(_flag(fake_popen[3].cmd, "--weights-json")) == {
+        "head_up": 1.0}
+    asyncio.run(stop())
+
+
 def test_adopted_job_survives_the_lab_poll_cycle(fake_popen):
     """The adopted job has no subprocess: the lab loop's poll()/stop()/
     stats.sample() must all be safe with proc=None, and poll() replays the


### PR DESCRIPTION
## Problem

`RecipeEditor` sent only the touched sliders plus added catalog terms as `weights`, and `POST /teach` treats an explicit `weights` dict as the complete override set (it replaces the sticky set). Observed in the browser on 2026-09-04: a finished imitate run seated via `POST /teach/load` whose `behavior.json` had `{"rotation_match": 6.05}` was retrained after adding one catalog term. The new run trained with `{"stay_upright": 1.5}` only and `rotation_match` fell back to the recipe default 4.00, with no message.

## Fix

- **Viewer** (`duck-viewer/components/TeachPanel.tsx`): retrain and fine-tune now submit every recipe term at its effective weight (the streamed `t.weights`, i.e. what the seated run actually trained under) with moved sliders and added terms folded in. The chat note still counts only the real edits.
- **Server** (`microduck_local/src/microduck_local/viz_server.py`): with `initFrom`, the request's weights merge over that run's `behavior.json` instead of replacing the sticky set. A fine-tune continues that brain, so its recipe is the base. An explicit key still wins, no weights means exactly what the run had, and a run predating `behavior.json` falls back to the request alone. The `initFrom` + `startStage` chain path keeps its old semantics, since the donor brain may be a different behavior. Retrain without `initFrom` still treats explicit weights as the complete set, which is safe now that the viewer sends the full set.
- **Test** (`microduck_local/tests/test_lab.py`): seats a cranked run via `/teach/load`, fine-tunes it with only an added catalog term, and asserts the trainer argv, the payload and the sticky file all carry both. Also covers an explicit override winning, no weights at all, and a bare run without `behavior.json`.

## Verification

- `uv run --with pytest pytest tests/test_lab.py` — 100 passed
- `npm run lint` — clean
- `npx tsc --noEmit` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
